### PR TITLE
feat: Add MarkdownTable to output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ OPTIONS:
 
     -o, --output <OUTPUT>
             Output format for the list of deprecated APIs [default: table] [possible values: table,
-            csv]
+            csv, markdown-table]
 
     -t, --target-version <TARGET_VERSION>
             list of deprecated APIs in a specific kubernetes version, -t 1.22. If -t not supplied,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use clap::ArgEnum;
-use comfy_table::{ContentArrangement, Table};
+use comfy_table::{presets::ASCII_MARKDOWN, ContentArrangement, Table};
 use csv::Writer;
 use env_logger::{Builder, Env};
 use log::{debug, info};
@@ -67,6 +67,23 @@ impl VecTableDetails {
         );
         Ok(())
     }
+    pub fn generate_markdown_table(self, column_replace: &str) -> Result<()> {
+        let mut t = Table::new();
+        let t = generate_table_header(&mut t, column_replace);
+        t.load_preset(ASCII_MARKDOWN);
+        for r in self.0 {
+            t.add_row(vec![
+                r.kind,
+                r.namespace,
+                r.name,
+                r.deprecated_api_version,
+                r.supported_api_version,
+                r.k8_version,
+            ]);
+        }
+        println!("{t}");
+        Ok(())
+    }
 }
 
 pub fn generate_table_header<'a>(t: &'a mut Table, column_replace: &str) -> &'a mut Table {
@@ -122,6 +139,7 @@ pub fn init_logger() {
 pub enum Output {
     Table,
     Csv,
+    MarkdownTable,
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -179,6 +197,9 @@ pub trait Finder {
                 }
                 Output::Table => {
                     x.generate_table(col_replace)?;
+                }
+                Output::MarkdownTable => {
+                    x.generate_markdown_table(col_replace)?;
                 }
             }
         } else {

--- a/tests/all/utils.rs
+++ b/tests/all/utils.rs
@@ -65,6 +65,21 @@ async fn test_csv_generation() {
 }
 
 #[tokio::test]
+async fn test_markdown_table_generation() {
+    let t = TableDetails {
+        kind: "ValidatingWebhookConfiguration".to_string(),
+        namespace: "".to_string(),
+        name: "istiod-istio-system".to_string(),
+        deprecated_api_version: "admissionregistration.k8s.io/v1beta1".to_string(),
+        supported_api_version: "admissionregistration.k8s.io/v1".to_string(),
+        k8_version: "1.22".to_string(),
+    };
+    let table = VecTableDetails(vec![t]);
+    let x = table.generate_markdown_table("Namespace");
+    assert!(x.is_ok());
+}
+
+#[tokio::test]
 async fn test_process_generate_table() {
     struct Te;
     #[async_trait]


### PR DESCRIPTION
fix https://github.com/maheshrayas/kube-depre/issues/36


It works as follows:

```
$ ./kube-depre -h
kube-depre 0.1.16

USAGE:
    kube-depre [OPTIONS]

OPTIONS:
    -d, --debug
            supply --debug to print the debug information

    -f, --file <FILE>
            supply -f or --file "Manifest file directory". if -f not supplied, it will by default
            query the cluster

    -h, --help
            Print help information

    -o, --output <OUTPUT>
            Output format for the list of deprecated APIs [default: table] [possible values: table,
            csv, markdown-table]
    : (snip)
```

```
$ ./kube-depre -f manifests/hoge.yaml -o markdown-table
: (snip)
| Kind    | Filename  | Name                 | DeprecatedApiVersion | SupportedApiVersion  | K8sVersion |
|---------|-----------|----------------------|----------------------|----------------------|------------|
| Ingress | hoge.yaml | istio-ingressgateway | extensions/v1beta1   | networking.k8s.io/v1 | 1.22       |
```
